### PR TITLE
chore: replace bump2version with python-semantic-release [#2][#3]

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,3 +25,25 @@ jobs:
 
       - name: Run tests
         run: inv t
+
+  release:
+    needs:
+      - build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: pip3 install -r dev-requirements.txt
+
+      - name: Run Release
+        run: |
+          git config --global user.email "bots@swellaby.com"
+          git config --global user.name "Semantic Release Bot"
+          semantic-release publish
+        env:
+          REPOSITORY_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,7 @@ pytest-cov==3.0.0
 pycodestyle==2.8.0
 black==19.10b0
 invoke==1.7.0
-bump2version==1.0.0
+python-semantic-release==7.28.1
+twine==4.0.0
+setuptools==62.1.0
+wheel==0.37.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[semantic_release]
+version_variable = anrufungen/version.py:__version__
+branch = main
+commit_subject = chore: release {version} [skip ci] ***NO_CI***


### PR DESCRIPTION
Requires `REPOSITORY_PASSWORD` to be set as a secret which contains the PYPI publish token